### PR TITLE
Fixed crash on hitDeltaBar if pressing buttons before chart is loaded.

### DIFF
--- a/scripts/gameplay.lua
+++ b/scripts/gameplay.lua
@@ -114,7 +114,7 @@ function button_hit(btn, rating, delta)
 		hitAnimations:enqueueHit(btn, delta, rating)
 	end
 
-	if hitDeltaBarEnabled and (not gameplay.autoplay) then
+	if hitDeltaBarEnabled and (not gameplay.autoplay) and (gameplay.progress ~= nil) then
 		hitDeltaBar:enqueueHit(btn, delta, rating)
 	end
 


### PR DESCRIPTION
Currently, if you have the hit delta bar enabled and you select a chart, the game will crash if you input buttons while the chart is loading. I think it was because it was trying to draw the hit, but there was nothing to draw so it crashed. I added a check to make sure the song has any progress before trying to draw anything so it won't crash.